### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-stage",
   "description": "A modern, type-safe Next.js starter template designed for AI-driven development",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "Kazuki Yonemoto (https://dev.to/tim_yone)",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps the package version `0.3.2` → `0.3.3` for the next release.

This release bundles the work merged in #49:
- Dependency vulnerability remediation (OSV/CVE scan): tar, glob, minimatch, picomatch, brace-expansion, js-yaml, uuid
- Next.js 16.2.10 and other dependency updates
- Rule-file (AGENTS/CLAUDE/GEMINI + _llm-rules) version sync

## Notes
- `0.3.2` was set in package.json previously but never tagged/released; this consolidates everything under `0.3.3`.
- After merge, tag `v0.3.3` and publish the GitHub release.

## Test plan
- [x] `bun install`
- [x] `bun run check`
- [x] `bun run build`

Made with [Cursor](https://cursor.com)